### PR TITLE
add OpenBSD to dllmap

### DIFF
--- a/SDL2-CS.dll.config
+++ b/SDL2-CS.dll.config
@@ -2,4 +2,5 @@
 <configuration>
 	<dllmap os="osx" dll="SDL2.dll" target="libSDL2.dylib"/>
 	<dllmap os="linux" dll="SDL2.dll" target="libSDL2-2.0.so.0" />
+	<dllmap os="openbsd" dll="SDL2.dll" target="libSDL2.so" />
 </configuration>


### PR DESCRIPTION
simple addition to `.dll.config` file, per platform conventions