### PR TITLE
Fixed Mono-specific .dll.config library targets

### DIFF
--- a/SDL2-CS.dll.config
+++ b/SDL2-CS.dll.config
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-	<dllmap dll="SDL2.dll" os="!windows" target="libSDL2-2.0.so.0" />
-	<dllmap dll="SDL2.dll" os="openbsd" target="libSDL2.so" />
-	<dllmap dll="SDL2.dll" os="osx" target="libSDL2.dylib"/>
+	<dllmap dll="SDL2" os="!windows" target="SDL2.so" />
+	<dllmap dll="SDL2" os="osx" target="SDL2.dylib"/>
 </configuration>


### PR DESCRIPTION
The new packages were not working under Mono.

A test run can be found at:
https://github.com/penev92/SDL2-CS/actions/runs/5221497947
https://www.nuget.org/packages/OpenRA-SDL2-CS/1.0.39-a2


Explanation: .NET would ignore the `dllmap` configuration that Mono uses (seems to be a Mono feature - https://learn.microsoft.com/en-us/samples/dotnet/samples/dllmap-demo/ )
so the 1.0.38 would work on Linux with .NET6, but would fail with Mono.