### PR TITLE
Update SDL to 2.30.9

### DIFF
--- a/.github/workflows/build-natives.yml
+++ b/.github/workflows/build-natives.yml
@@ -3,7 +3,7 @@ name: Build native dependencies (SDL2)
 # Change SDL2 version based on https://github.com/libsdl-org/SDL/releases, but remember to check what SDL2 version SDL2-CS targets.
 # Change Chromium revision numbers based on https://chromium.woolyss.com/download/.
 env:
-    SDL2_VERSION: 2.30.6 # Make sure this matches the version mentioned in the description in the .nuspec file.
+    SDL2_VERSION: 2.30.9 # Make sure this matches the version mentioned in the description in the .nuspec file.
     CHROMIUM_BUILD_x86: 1136315
     CHROMIUM_BUILD_x64: 1136314
 

--- a/OpenRA-SDL2-CS.nuspec
+++ b/OpenRA-SDL2-CS.nuspec
@@ -9,7 +9,7 @@
     <requireLicenseAcceptance>false</requireLicenseAcceptance>
     <description>
     This is a version of SDL2-CS modified and packaged for OpenRA.
-    The package includes the C# wrapper (SDL2-CS) and the native binaries for SDL2 and targets version 2.30.6 of the native project.
+    The package includes the C# wrapper (SDL2-CS) and the native binaries for SDL2 and targets version 2.30.9 of the native project.
     </description>
     <copyright>
     - Copyright (c) 2013-2021 Ethan Lee

--- a/src/SDL2.cs
+++ b/src/SDL2.cs
@@ -806,6 +806,10 @@ namespace SDL2
 		public const string SDL_HINT_QUIT_ON_LAST_WINDOW_CLOSE =
 			"SDL_QUIT_ON_LAST_WINDOW_CLOSE";
 
+		/* Only available in 2.24.0 or higher. */
+		public const string SDL_HINT_MAC_OPENGL_ASYNC_DISPATCH =
+			"SDL_MAC_OPENGL_ASYNC_DISPATCH";
+
 		public enum SDL_HintPriority
 		{
 			SDL_HINT_DEFAULT,


### PR DESCRIPTION
supersedes #18

https://github.com/libsdl-org/SDL/releases/tag/release-2.30.9

https://github.com/libsdl-org/SDL/releases/tag/release-2.24.0
https://github.com/libsdl-org/SDL/blob/main/include/SDL3/SDL_hints.h#L2313

https://github.com/OpenRA/OpenRA/pull/21644
